### PR TITLE
Update requirements.txt to include pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests-html==0.10.0
 requests-oauthlib==1.3.1
 requests-toolbelt==0.9.1
 pillow
+pydantic==1.10.7


### PR DESCRIPTION
To fix the error "ModuleNotFoundError: No module named 'pydantic'" when running `python raw_data.py`.