### PR TITLE
light cones model

### DIFF
--- a/hsr_client/__init__.py
+++ b/hsr_client/__init__.py
@@ -1,8 +1,8 @@
-from abc import ABC
-
+from typing import List
 from hsr_client.constants import Languages, Types
 from hsr_client.backend import BackendAdapter
 from hsr_client import datamodels as models
+from hsr_client.datamodels.lightcone import Lightcone
 
 
 # Public facing api client.
@@ -13,23 +13,26 @@ class HsrClient:
         # just using SRSBackend here would have been enough.
         self.adapter = BackendAdapter()
     
-        # our own api related logic goes here
-        # in this case, looping and searching.
-        # here we have the convinience of working with our own data models. (ex: Trace)
-    def find_trace(self, trace_name) -> models.trace.Trace:
-        # for trace in self.adapter().fetch_traces():
-        #     if trace.name  == trace_name:
-        #         return 
-        ...
+    # # our own api related logic goes here
+    # # in this case, looping and searching.
+    # # here we have the convinience of working with our own data models. (ex: Trace)
+    # def find_trace(self, trace_name) -> models.trace.Trace:
+    #     # for trace in self.adapter().fetch_traces():
+    #     #     if trace.name  == trace_name:
+    #     #         return 
+    #     ...
 
-    def get_character(self, chara_name) -> models.chara.Character:
-        # nothing else to do here.
-        return self.adapter().get_character(chara_name)
+    # def get_character(self, chara_name) -> models.chara.Character:
+    #     # nothing else to do here.
+    #     return self.adapter().get_character(chara_name)
 
 
 
-    def get_lightcones(self):
-        self.adapter().get_lightcones()
+    def get_lightcones(self) -> List[Lightcone]:
+        # self.adapter().get_lightcones() ??
+        return []
+
+
 
 if __name__ == "__main__":
     client = HsrClient()

--- a/hsr_client/datamodels/lightcone.py
+++ b/hsr_client/datamodels/lightcone.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, NewType, Tuple, Iterable
 from pydantic import BaseModel
 from hsr_client.datamodels.material import Material
 from hsr_client.stats import Stats
@@ -9,12 +9,24 @@ class Stats(BaseModel):
     HP: int
     DEF: int
 
+Level = int
+Count = int
+Superimposition = int
 
 
-class Scaling(BaseModel):
-    """light cone scaling for a given level."""
-    upgrade_mats: List[Tuple[Material, int]]
-    description: str
+class AscensionMaterial(BaseModel):
+
+    material: Material
+    count: int
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def __iter__(self):
+        return iter(self.mats)
+
+
+
 
 class Lightcone(BaseModel):
     """
@@ -23,16 +35,55 @@ class Lightcone(BaseModel):
    Attributes:
         name: name of the lightcone
         description: description of the lightcone
-        level_scaling: lightcone scaling by leve. {level: Scaling}
+        path: Path association of the Lightcone
+        scaling: lightcone scaling by level. key: level, value: Stats
+        ability: lightcone ability description for given superimposition (int)
+        ascension_mats: ascension materials required to level up beyond given `Level` (int)
     """
     name: str
     # ligthcone rarity
     rarity: int
     description: str
-    stats: Stats
     path: Path
-    # lightcone scaling by level. `{level: Scaling}`
-    scaling: Dict[int, Scaling]
-    # light cone ability by superimposition
-    ability: Dict[int, str]
+    # lightcone stats scaling by `Level` (int)
+    stats: Dict[Level, Stats]
+    # lightcone ability description for given `Superimposition` (int)
+    ability: Dict[Superimposition, str]
 
+    # TODO: type too long? should we break it down?
+    # ascension materials required to level up beyond given `Level` (int)
+    ascension_mats: Dict[Level, List[Dict[Material, Count]]]
+
+
+if __name__ == "__main__":
+
+    lightcone = Lightcone(
+        name="light cone",
+        rarity=4,
+        description="this is a light cone , and this is its history",
+        path = Path.Harmony,
+        stats = {
+            1: Stats(
+                ATK=12,
+                HP=13,
+                DEF=14,
+            )
+        },
+        ability={
+            1: "at superimposition level damage bonus is 30%"
+        },
+        ascension_mats={
+        20: [
+            {Material(name="foo1", description="bar1"): 1},
+            {Material(name="foo2", description="bar2"): 2}
+        ],
+        30: [
+            {Material(name="foo3", description="bar3"): 3}
+        ]
+    })
+
+    lvl_20_ascension_mats = lightcone.ascension_mats[20] # TODO: this doesn't read well. what does ascension_mats[20] mean, unless u look at the type.
+
+    for mats in lvl_20_ascension_mats:
+        print("mats:" , mats.keys())
+        print("count: ", mats.values())

--- a/hsr_client/datamodels/lightcone.py
+++ b/hsr_client/datamodels/lightcone.py
@@ -19,11 +19,6 @@ class AscensionMaterial(BaseModel):
     material: Material
     count: int
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def __iter__(self):
-        return iter(self.mats)
 
 
 
@@ -52,7 +47,7 @@ class Lightcone(BaseModel):
 
     # TODO: type too long? should we break it down?
     # ascension materials required to level up beyond given `Level` (int)
-    ascension_mats: Dict[Level, List[Dict[Material, Count]]]
+    ascension_mats: Dict[Level, List[AscensionMaterial]]
 
 
 if __name__ == "__main__":
@@ -74,16 +69,16 @@ if __name__ == "__main__":
         },
         ascension_mats={
         20: [
-            {Material(name="foo1", description="bar1"): 1},
-            {Material(name="foo2", description="bar2"): 2}
+            AscensionMaterial(material=Material(name="foo1", description="bar1"), count=1),
+            AscensionMaterial(material=Material(name="foo2", description="bar2"), count=2),
         ],
         30: [
-            {Material(name="foo3", description="bar3"): 3}
+            AscensionMaterial(material=Material(name="foo3", description="bar3"), count=3),
         ]
     })
 
     lvl_20_ascension_mats = lightcone.ascension_mats[20] # TODO: this doesn't read well. what does ascension_mats[20] mean, unless u look at the type.
 
-    for mats in lvl_20_ascension_mats:
-        print("mats:" , mats.keys())
-        print("count: ", mats.values())
+    for mat in lvl_20_ascension_mats:
+        print("mat: ", mat.material)
+        print("count: ", mat.count)

--- a/hsr_client/datamodels/material.py
+++ b/hsr_client/datamodels/material.py
@@ -9,5 +9,3 @@ class Material(BaseModel):
     pass
 
 
-    def __hash__(self):
-        return hash(self.name)

--- a/hsr_client/datamodels/material.py
+++ b/hsr_client/datamodels/material.py
@@ -1,4 +1,13 @@
 from pydantic import BaseModel
 
 class Material(BaseModel):
+    name: str
+    description: str
+
+    # TODO: determine icon stratergy
+    # is it image, or url or what?
     pass
+
+
+    def __hash__(self):
+        return hash(self.name)


### PR DESCRIPTION
This is a draft pull requests. idea is to discuss , make additional changes before merging.

I'm kinda iffy about type definition for this property in light cone model  (see hsr_client/datamodels/lightcone.py in PR) the type feels too long for me, how do you feel about this.
```python
 ascension_mats: Dict[Level, List[Dict[Material, Count]]]
```

alternative is to create more sub types like 

```python
ascension_mats: Dict[Level, AscensionMaterials]
```
where, `AscensionMaterials` could be an iterator so we can do 

```python
for ascension_mat in ascenscion_mats:
    ...
`````

and `ascension_mat` could be of type `AscensionMaterial`

so we can do 

```python
ascension_mat.material # the `Material` required
ascension_mat.count # the number of such materials requred.
```

but this introduces 2 more types , unncessarily.

