### PR TITLE
removed sleep() from fetch data loop

### DIFF
--- a/raw_data.py
+++ b/raw_data.py
@@ -87,7 +87,7 @@ for type in Types:
             print(f'[downloading] [Language: {language}]', Types(entry.type).name, entry.name)
             with open(f'{save_path}/{language}/{folders[entry.type]}/{entry.id}.json', 'w') as f:
                 dump(data, f, indent=1)
-            sleep(2)
+
 
 print(f'[downloading] [Language: {language}]', 'ACHIEVEMENTS')   
 data = client.fetch(language, ACHIEVEMENTS, None)


### PR DESCRIPTION
is this to prevent rate-limiting?
i realized the program sends a get request to an api of some sort with changing id number

I only ran this once if its of concern.

cuts down `raw_data.py` runtime to 1 minute, from 25 minutes (on a desktop 5600G)
